### PR TITLE
Overlayfs devel

### DIFF
--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/config
@@ -4,18 +4,32 @@
 
 DEFAULT_MKFS_OPTIONS=""
 
+function __fsck()
+{
+	local dev="$1"
+
+	case "$FSTESTTYP" in
+	    ext4)
+		/sbin/e2fsck -fy "$dev"
+		;;
+	    xfs)
+		xfs_repair "$dev"
+		;;
+	esac
+}
+
 function check_filesystem()
 {
 	umount $SM_TST_DEV >& /dev/null
-	/sbin/e2fsck -fy "$SM_TST_DEV"
+	__fsck "$SM_TST_DEV"
 	ret="$?"
-	mount -t ext4 $SM_TST_DEV $SM_TST_MNT
+	mount -t $FSTESTTYP $SM_TST_DEV $SM_TST_MNT
 	echo e2fsck exited with status "$ret"
 
 	umount $SM_SCR_DEV >& /dev/null
-	/sbin/e2fsck -fy "$SM_SCR_DEV"
+	__fsck "$SM_SCR_DEV"
 	ret2="$?"
-	mount -t ext4 $SM_SCR_DEV $SM_SCR_MNT
+	mount -t $FSTESTTYP $SM_SCR_DEV $SM_SCR_MNT
 	echo e2fsck exited with status "$ret2"
 
 	if test "$ret" -eq 0 ; then
@@ -24,16 +38,30 @@ function check_filesystem()
 	return "$ret"
 }
 
+function __mkfs()
+{
+	local dev="$1"
+
+	case "$FSTESTTYP" in
+	    ext4)
+		/sbin/mke2fs -F -q -t ext4 "$dev"
+		;;
+	    xfs)
+		mkfs.xfs -f -m rmapbt=1,reflink=1 "$dev"
+		;;
+	esac
+}
+
 function format_filesystem()
 {
 	umount $SM_TST_DEV >& /dev/null
-	/sbin/mke2fs -F -q -t ext4 $SM_TST_DEV
-	mount -t ext4 $SM_TST_DEV $SM_TST_MNT
+	__mkfs $SM_TST_DEV
+	mount -t $FSTESTTYP $SM_TST_DEV $SM_TST_MNT
 	mkdir -p $SM_TST_MNT/ovl $SM_TST_MNT/testarea
 	      
 	umount $SM_SCR_DEV >& /dev/null
-	/sbin/mke2fs -F -q -t ext4 $SM_SCR_DEV
-	mount -t ext4 $SM_SCR_DEV $SM_SCR_MNT
+	__mkfs $SM_SCR_DEV
+	mount -t $FSTESTTYP $SM_SCR_DEV $SM_SCR_MNT
 	mkdir -p $SM_SCR_MNT/ovl $SM_SCR_MNT/testarea
 
 	return 0

--- a/kvm-xfstests/test-appliance/files/root/fs/xfs/cfg/reflink
+++ b/kvm-xfstests/test-appliance/files/root/fs/xfs/cfg/reflink
@@ -1,0 +1,3 @@
+SIZE=small
+export XFS_MKFS_OPTIONS="-m rmapbt=1,reflink=1"
+TESTNAME="XFS reflink"

--- a/kvm-xfstests/util/parse_cli
+++ b/kvm-xfstests/util/parse_cli
@@ -59,7 +59,7 @@ print_help ()
 validate_test_name()
 {
     case "$1" in
-	btrfs*|cifs*|ext4*|generic*|shared*|udf*|xfs*) ;;
+	btrfs*|cifs*|ext4*|generic*|shared*|udf*|xfs*|overlay*) ;;
 	*)
 	    echo -e "Invalid test name: $1\n"
 	    print_help


### PR DESCRIPTION
Having a little fun. Decided to send this one out also as a github PR.

With this change, one is not limited to testing overlayfs over ext4
and one can test drive XFS reflink, which is queued in xfsprogs for-next branch
and test drive overlayfs clone-up, which is queued in overlayfs-next branch.