### PR TITLE
test-appliance: create 'overlay/large' config

### DIFF
--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/all.list
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/all.list
@@ -1,1 +1,2 @@
-default
+small
+large

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/default
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/default
@@ -1,7 +1,0 @@
-export TEST_DEV=$SM_TST_MNT/ovl
-export TEST_DIR=$SM_TST_MNT/testarea
-export SCRATCH_DEV=$SM_SCR_MNT/ovl
-export SCRATCH_MNT=$SM_SCR_MNT/testarea
-export EXT_MOUNT_OPTIONS=""
-TESTNAME="overlayfs"
-mkdir -p /test/tmp /test/scratch

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/large
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/large
@@ -1,0 +1,18 @@
+function check_filesystem()
+{
+	__check_filesystem "$LG_TST_DEV" "$LG_TST_MNT" "$LG_SCR_DEV" "$LG_SCR_MNT"
+}
+
+function format_filesystem()
+{
+	__format_filesystem "$LG_TST_DEV" "$LG_TST_MNT" "$LG_SCR_DEV" "$LG_SCR_MNT"
+}
+
+SIZE=large
+export TEST_DEV=$LG_TST_MNT/ovl
+export TEST_DIR=$LG_TST_MNT/testarea
+export SCRATCH_DEV=$LG_SCR_MNT/ovl
+export SCRATCH_MNT=$LG_SCR_MNT/testarea
+export EXT_MOUNT_OPTIONS=""
+TESTNAME="overlayfs large"
+mkdir -p /test/tmp /test/scratch

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/small
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/small
@@ -1,0 +1,18 @@
+function check_filesystem()
+{
+	__check_filesystem "$SM_TST_DEV" "$SM_TST_MNT" "$SM_SCR_DEV" "$SM_SCR_MNT"
+}
+
+function format_filesystem()
+{
+	__format_filesystem "$SM_TST_DEV" "$SM_TST_MNT" "$SM_SCR_DEV" "$SM_SCR_MNT"
+}
+
+SIZE=small
+export TEST_DEV=$SM_TST_MNT/ovl
+export TEST_DIR=$SM_TST_MNT/testarea
+export SCRATCH_DEV=$SM_SCR_MNT/ovl
+export SCRATCH_MNT=$SM_SCR_MNT/testarea
+export EXT_MOUNT_OPTIONS=""
+TESTNAME="overlayfs small"
+mkdir -p /test/tmp /test/scratch

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/small.exclude
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/small.exclude
@@ -1,0 +1,1 @@
+overlay/001	# requires (2*4G + 8k) free space on $SCRATCH_DEV.

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/config
@@ -18,24 +18,35 @@ function __fsck()
 	esac
 }
 
-function check_filesystem()
+function __check_filesystem()
 {
-	umount $SM_TST_DEV >& /dev/null
-	__fsck "$SM_TST_DEV"
+	local tst_dev="$1"
+	local tst_mnt="$2"
+	local scr_dev="$3"
+	local scr_mnt="$4"
+
+	umount $tst_dev >& /dev/null
+	__fsck "$tst_dev"
 	ret="$?"
-	mount -t $FSTESTTYP $SM_TST_DEV $SM_TST_MNT
+	mount -t $FSTESTTYP $tst_dev $tst_mnt
 	echo e2fsck exited with status "$ret"
 
-	umount $SM_SCR_DEV >& /dev/null
-	__fsck "$SM_SCR_DEV"
+	umount $scr_dev >& /dev/null
+	__fsck "$scr_dev"
 	ret2="$?"
-	mount -t $FSTESTTYP $SM_SCR_DEV $SM_SCR_MNT
+	mount -t $FSTESTTYP $scr_dev $scr_mnt
 	echo e2fsck exited with status "$ret2"
 
 	if test "$ret" -eq 0 ; then
 		ret=$ret2
 	fi
 	return "$ret"
+}
+
+function check_filesystem()
+{
+	echo check_filesystem\(\) should be overriden by a test cfg file.
+	return -1
 }
 
 function __mkfs()
@@ -52,19 +63,30 @@ function __mkfs()
 	esac
 }
 
-function format_filesystem()
+function __format_filesystem()
 {
-	umount $SM_TST_DEV >& /dev/null
-	__mkfs $SM_TST_DEV
-	mount -t $FSTESTTYP $SM_TST_DEV $SM_TST_MNT
-	mkdir -p $SM_TST_MNT/ovl $SM_TST_MNT/testarea
-	      
-	umount $SM_SCR_DEV >& /dev/null
-	__mkfs $SM_SCR_DEV
-	mount -t $FSTESTTYP $SM_SCR_DEV $SM_SCR_MNT
-	mkdir -p $SM_SCR_MNT/ovl $SM_SCR_MNT/testarea
+	local tst_dev="$1"
+	local tst_mnt="$2"
+	local scr_dev="$3"
+	local scr_mnt="$4"
+
+	umount $tst_dev >& /dev/null
+	__mkfs $tst_dev
+	mount -t $FSTESTTYP $tst_dev $tst_mnt
+	mkdir -p $tst_mnt/ovl $tst_mnt/testarea
+
+	umount $scr_dev >& /dev/null
+	__mkfs $scr_dev
+	mount -t $FSTESTTYP $scr_dev $scr_mnt
+	mkdir -p $scr_mnt/ovl $scr_mnt/testarea
 
 	return 0
+}
+
+function format_filesystem()
+{
+	echo format_filesystem\(\) should be overriden by a test cfg file.
+	return -1
 }
 
 function setup_mount_opts()
@@ -96,7 +118,10 @@ function show_mount_opts()
 
 function test_name_alias()
 {
-    echo "$1"
+    case "$1" in
+	default)	echo "small" ;;
+	*)		echo "large" ;;
+    esac
 }
 
 function reset_vars()


### PR DESCRIPTION
Currently the test overlay/001 does not run, because it requires
larger devices while the configuration sets up small devices only.

This patch adds 'overlay/large' config to let users run overlay/001.

Signed-off-by: Edward Hyunkoo Jee <edjee@google.com>