### PR TITLE
Support xfstest -x group command line option

### DIFF
--- a/kvm-xfstests/util/parse_cli
+++ b/kvm-xfstests/util/parse_cli
@@ -26,6 +26,7 @@ print_help ()
     fi
     echo "	-o opts		- Extra kernel command line options"
     echo "	-r ram		- Specify memory to be used in megabytes"
+    echo "	-x group	- Exclude group of tests from running"
     echo "	-X test		- Exclude test from running"
     echo "	--kernel file	- Boot the specified kernel"
     if test "$GCE_XFSTESTS" != "yes" ; then
@@ -154,6 +155,9 @@ while [ "$1" != "" ]; do
 	    ;;
 	-g) shift
 	    FSTESTSET="$FSTESTSET,-g,$1"
+	    ;;
+	-x) shift
+	    FSTESTSET="$FSTESTSET,-x,$1"
 	    ;;
 	-h|--help|help)
 	    print_help


### PR DESCRIPTION
Note that while kvm-xfstests -X <test> is NOT equivalent to
the check -X command line option, kvm-xfstests -x <group> is
exactly the same as check -x <group>.

Signed-off-by: Amir Goldstein <amir73il@gmail.com>