### PR TITLE
test-appliance: use new overlay xfstest config

### DIFF
--- a/kvm-xfstests/test-appliance/files/root/fs/btrfs/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/btrfs/config
@@ -30,9 +30,9 @@ function setup_mount_opts()
 {
     if test -n "$MNTOPTS" ; then
 	if test -n "$MOUNT_OPTIONS" ; then
-            MOUNT_OPTIONS="$MOUNT_OPTIONS,$MNTOPTS"
+            export MOUNT_OPTIONS="$MOUNT_OPTIONS,$MNTOPTS"
 	else
-	    MOUNT_OPTIONS="-o $MNTOPTS"
+	    export MOUNT_OPTIONS="-o $MNTOPTS"
 	fi
     fi
 }

--- a/kvm-xfstests/test-appliance/files/root/fs/ext2/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/ext2/config
@@ -30,9 +30,9 @@ function setup_mount_opts()
 {
     if test -n "$MNTOPTS" ; then
 	if test -n "$EXT_MOUNT_OPTIONS" ; then
-            EXT_MOUNT_OPTIONS="$EXT_MOUNT_OPTIONS,$MNTOPTS"
+            export EXT_MOUNT_OPTIONS="$EXT_MOUNT_OPTIONS,$MNTOPTS"
 	else
-	    EXT_MOUNT_OPTIONS="-o $MNTOPTS"
+	    export EXT_MOUNT_OPTIONS="-o $MNTOPTS"
 	fi
     fi
 }

--- a/kvm-xfstests/test-appliance/files/root/fs/ext4/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/ext4/config
@@ -30,12 +30,12 @@ function setup_mount_opts()
 {
     export MKFS_OPTIONS="$EXT_MKFS_OPTIONS"
     if test -n "$EXT_MOUNT_OPTIONS" ; then
-	EXT_MOUNT_OPTIONS="-o block_validity,$EXT_MOUNT_OPTIONS"
+	export EXT_MOUNT_OPTIONS="-o block_validity,$EXT_MOUNT_OPTIONS"
     else
-	EXT_MOUNT_OPTIONS="-o block_validity"
+	export EXT_MOUNT_OPTIONS="-o block_validity"
     fi
     if test -n "$MNTOPTS" ; then
-	EXT_MOUNT_OPTIONS="$EXT_MOUNT_OPTIONS,$MNTOPTS"
+	export EXT_MOUNT_OPTIONS="$EXT_MOUNT_OPTIONS,$MNTOPTS"
     fi
     if echo "$EXT_MOUNT_OPTIONS" | grep -q test_dummy_encryption; then
         local mode='\x00\x00\x00\x00'

--- a/kvm-xfstests/test-appliance/files/root/fs/f2fs/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/f2fs/config
@@ -28,9 +28,9 @@ function setup_mount_opts()
 {
     if test -n "$MNTOPTS" ; then
 	if test -n "$F2FS_MOUNT_OPTIONS" ; then
-	    F2FS_MOUNT_OPTIONS="$F2FS_MOUNT_OPTIONS,$MNTOPTS"
+	    export F2FS_MOUNT_OPTIONS="$F2FS_MOUNT_OPTIONS,$MNTOPTS"
 	else
-	    F2FS_MOUNT_OPTIONS="-o $MNTOPTS"
+	    export F2FS_MOUNT_OPTIONS="-o $MNTOPTS"
 	fi
     fi
 }

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/large
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/large
@@ -13,6 +13,5 @@ export TEST_DEV=$LG_TST_DEV
 export TEST_DIR=$LG_TST_MNT
 export SCRATCH_DEV=$LG_SCR_DEV
 export SCRATCH_MNT=$LG_SCR_MNT
-export EXT_MOUNT_OPTIONS=""
 TESTNAME="overlayfs large"
 mkdir -p /test/tmp /test/scratch

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/large
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/large
@@ -9,10 +9,10 @@ function format_filesystem()
 }
 
 SIZE=large
-export TEST_DEV=$LG_TST_MNT/ovl
-export TEST_DIR=$LG_TST_MNT/testarea
-export SCRATCH_DEV=$LG_SCR_MNT/ovl
-export SCRATCH_MNT=$LG_SCR_MNT/testarea
+export TEST_DEV=$LG_TST_DEV
+export TEST_DIR=$LG_TST_MNT
+export SCRATCH_DEV=$LG_SCR_DEV
+export SCRATCH_MNT=$LG_SCR_MNT
 export EXT_MOUNT_OPTIONS=""
 TESTNAME="overlayfs large"
 mkdir -p /test/tmp /test/scratch

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/small
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/small
@@ -9,10 +9,10 @@ function format_filesystem()
 }
 
 SIZE=small
-export TEST_DEV=$SM_TST_MNT/ovl
-export TEST_DIR=$SM_TST_MNT/testarea
-export SCRATCH_DEV=$SM_SCR_MNT/ovl
-export SCRATCH_MNT=$SM_SCR_MNT/testarea
+export TEST_DEV=$SM_TST_DEV
+export TEST_DIR=$SM_TST_MNT
+export SCRATCH_DEV=$SM_SCR_DEV
+export SCRATCH_MNT=$SM_SCR_MNT
 export EXT_MOUNT_OPTIONS=""
 TESTNAME="overlayfs small"
 mkdir -p /test/tmp /test/scratch

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/small
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/cfg/small
@@ -13,6 +13,5 @@ export TEST_DEV=$SM_TST_DEV
 export TEST_DIR=$SM_TST_MNT
 export SCRATCH_DEV=$SM_SCR_DEV
 export SCRATCH_MNT=$SM_SCR_MNT
-export EXT_MOUNT_OPTIONS=""
 TESTNAME="overlayfs small"
 mkdir -p /test/tmp /test/scratch

--- a/kvm-xfstests/test-appliance/files/root/fs/overlay/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/overlay/config
@@ -92,10 +92,10 @@ function format_filesystem()
 function setup_mount_opts()
 {
     if test -n "$MNTOPTS" ; then
-	if test -n "OVERLAY_MOUNT_OPTIONS" ; then
-            OVERLAY_MOUNT_OPTIONS="$OVERLAY_MOUNT_OPTIONS,$MNTOPTS"
+	if test -n "$OVERLAY_MOUNT_OPTIONS" ; then
+            export OVERLAY_MOUNT_OPTIONS="$OVERLAY_MOUNT_OPTIONS,$MNTOPTS"
 	else
-	    OVERLAY_MOUNT_OPTIONS="-o $MNTOPTS"
+	    export OVERLAY_MOUNT_OPTIONS="-o $MNTOPTS"
 	fi
     fi
 }

--- a/kvm-xfstests/test-appliance/files/root/fs/tmpfs/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/tmpfs/config
@@ -18,9 +18,9 @@ function setup_mount_opts()
 {
     if test -n "$MNTOPTS" ; then
 	if test -n "$TMPFS_MOUNT_OPTIONS" ; then
-            TMPFS_MOUNT_OPTIONS="$TMPFS_MOUNT_OPTIONS,$MNTOPTS"
+            export TMPFS_MOUNT_OPTIONS="$TMPFS_MOUNT_OPTIONS,$MNTOPTS"
 	else
-	    TMPFS_MOUNT_OPTIONS="-o $MNTOPTS"
+	    export TMPFS_MOUNT_OPTIONS="-o $MNTOPTS"
 	fi
     fi
 }

--- a/kvm-xfstests/test-appliance/files/root/fs/xfs/config
+++ b/kvm-xfstests/test-appliance/files/root/fs/xfs/config
@@ -30,9 +30,9 @@ function setup_mount_opts()
 {
     if test -n "$MNTOPTS" ; then
 	if test -n "$XFS_MOUNT_OPTIONS" ; then
-            XFS_MOUNT_OPTIONS="$XFS_MOUNT_OPTIONS,$MNTOPTS"
+            export XFS_MOUNT_OPTIONS="$XFS_MOUNT_OPTIONS,$MNTOPTS"
 	else
-	    XFS_MOUNT_OPTIONS="-o $MNTOPTS"
+	    export XFS_MOUNT_OPTIONS="-o $MNTOPTS"
 	fi
     fi
 }


### PR DESCRIPTION
requires xfstests commit 33e4199
("overlay: use OVL_BASE_SCRATCH_MNT instead of SCRATCH_DEV")

Signed-off-by: Amir Goldstein <amir73il@gmail.com>