### PR TITLE
test-appliance: define LOGWRITES_DEV for crash consistency tests

### DIFF
--- a/kvm-xfstests/test-appliance/files/root/runtests.sh
+++ b/kvm-xfstests/test-appliance/files/root/runtests.sh
@@ -276,9 +276,11 @@ do
 	    if test "$SIZE" = "large" ; then
 		export SCRATCH_DEV=$LG_SCR_DEV
 		export SCRATCH_MNT=$LG_SCR_MNT
+		export LOGWRITES_DEV=$SM_SCR_DEV
 	    else
 		export SCRATCH_DEV=$SM_SCR_DEV
 		export SCRATCH_MNT=$SM_SCR_MNT
+		export LOGWRITES_DEV=$LG_SCR_DEV
 	    fi
 	fi
 	case "$TEST_DEV" in


### PR DESCRIPTION
Define LOGWRITES_DEV to the small scratch dev when 'large' configuration
is used and to large scratch dev otherwise.

It is not likely that we will need a large log device for any test.

Signed-off-by: Amir Goldstein <amir73il@gmail.com>