### PR TITLE
Add missing packages to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,12 @@ RUN apt-get update && \
 	    libtool-bin \
 	    pkg-config \
 	    pigz \
-	    uuid-dev && \
+	    uuid-dev \
+	    libssl-dev \
+	    autopoint  \
+	    procps \
+	    python \
+	    python-future && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \
        /usr/share/doc /usr/share/doc-base \


### PR DESCRIPTION
This commmit adds libssl-dev and autopoint so that "docker build" would
successfully build a container image.  It also adds procps, python,
and python-future which are required by xfstests scripts.

Signed-off-by: Saied Kazemi <saied@google.com>