### PR TITLE
Update the default version of fio

### DIFF
--- a/config
+++ b/config
@@ -18,7 +18,7 @@ BLKTESTS_GIT=https://github.com/osandov/blktests.git
 # SYZKALLER_GIT=https://github.com/google/syzkaller
 # NVME_CLI_GIT=https://github.com/linux-nvme/nvme-cli
 
-FIO_COMMIT=fio-3.2
+FIO_COMMIT=fio-3.15
 QUOTA_COMMIT=59b280ebe22e
 XFSPROGS_COMMIT=v4.16.0
 


### PR DESCRIPTION
Bump the FIO to the latest version, so it can fix the gettid define
conflict for newer glibc.

This closes #23 

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>