### PR TITLE
gce-xfstests: Fix directory structure for '--update-files' option.

### DIFF
--- a/run-fstests/gce-xfstests
+++ b/run-fstests/gce-xfstests
@@ -821,12 +821,12 @@ if test -z "$NO_ACTION" -a "$UPDATE_FILES" = "yes"
 then
     LOCAL_FILES=$(mktemp /tmp/files.XXXXXXXX)
     GS_FILES="gs://$GS_BUCKET/files.tar.gz"
-    if ! test -d "$DIR/test-appliance"
+    if ! test -d "$DIR/../test-appliance"
     then
 	echo "Can't find the test-appliance directory!"
 	exit 1
     fi
-    (cd "$DIR/test-appliance"; \
+    (cd "$DIR/../test-appliance"; \
      tar -X gce-exclude-files --exclude=etc -C files \
 		--owner=root --group=root --mode=go+u-w -cf - . | \
 	 gzip -9n > $LOCAL_FILES)


### PR DESCRIPTION
After the directory structure changes, "-update-files" operation fails with "Can't find the test-appliance directory!" error message.

Signed-off-by: Meena Shanmugam <meenashanmugam@google.com>