### PR TITLE
gce-xfstests: Fix the --update-files option.

### DIFF
--- a/run-fstests/gce-xfstests
+++ b/run-fstests/gce-xfstests
@@ -826,7 +826,7 @@ then
 	echo "Can't find the test-appliance directory!"
 	exit 1
     fi
-    (cd "$DIR/test-appliance"; \
+    (cd "$DIR/../test-appliance"; \
      tar -X gce-exclude-files --exclude=etc -C files \
 		--owner=root --group=root --mode=go+u-w -cf - . | \
 	 gzip -9n > $LOCAL_FILES)


### PR DESCRIPTION
Since test-appliance directory is moved, fix it in gce-xfstests.

Signed-off-by: Meena Shanmugam <meenashanmugam@google.com>