### PR TITLE
gce-xfstests: fix grep command in image family fallback

### DIFF
--- a/run-fstests/gce-xfstests
+++ b/run-fstests/gce-xfstests
@@ -1183,7 +1183,7 @@ launch_vm 2> $ERRFILE
 if test "$err" -gt 0 ; then
     cat $ERRFILE
     if grep -q images/family/xfstests-amd64 $ERRFILE ; then
-	if grep -q "The project .* was not found" ; then
+	if grep -q "The project .* was not found" $ERRFILE; then
 	    exit $err
 	fi
 	echo Retrying with the image family xfstests


### PR DESCRIPTION
When checking the error output after a failed "launch_vm", there's a grep command that doesn't specify the file to grep, so it waits on stdin.

This fixes commit 0f7b3e19e8da0514f447b5126f76371afef89ac9

Signed-off-by: Ricardo Cañuelo <ricardo.canuelo@collabora.com>