### PR TITLE
test_appliance: add f2fs/compress config

### DIFF
--- a/test-appliance/files/root/fs/f2fs/cfg/all.list
+++ b/test-appliance/files/root/fs/f2fs/cfg/all.list
@@ -1,2 +1,3 @@
 default
 encrypt
+compress

--- a/test-appliance/files/root/fs/f2fs/cfg/compress
+++ b/test-appliance/files/root/fs/f2fs/cfg/compress
@@ -1,0 +1,5 @@
+SIZE=small
+export MKFS_OPTIONS="-O compression,extra_attr"
+export F2FS_MOUNT_OPTIONS="compress_extension=*"
+REQUIRE_FEATURE=compression
+TESTNAME="F2FS compression"


### PR DESCRIPTION
Add a f2fs/compress configuration which causes all files to be automatically compressed, similar to how f2fs/encrypt causes all files to be automatically encrypted.

Signed-off-by: Eric Biggers <ebiggers@google.com>