### PR TITLE
fstests-bld: use new git repo URL for fsverity-utils

### DIFF
--- a/fstests-bld/config
+++ b/fstests-bld/config
@@ -6,7 +6,7 @@ XFSTESTS_GIT=https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git
 XFSPROGS_GIT=https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git
 FIO_GIT=http://git.kernel.dk/fio.git
 QUOTA_GIT=https://git.kernel.org/pub/scm/utils/quota/quota-tools.git
-FSVERITY_GIT=https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git/
+FSVERITY_GIT=https://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git
 BLKTESTS_GIT=https://github.com/osandov/blktests.git
 
 # Optional repositories, uncomment only if needed

--- a/fstests-bld/config.docker
+++ b/fstests-bld/config.docker
@@ -12,7 +12,7 @@ QUOTA_COMMIT=d2256ac2d44b0a5be9c0b49ce4ce8e5f6821ce2a
 # SYZKALLER_GIT=https://github.com/google/syzkaller
 # SYZKALLER_COMMIT=2f93b54f26aa40233a0a584ce8714e55c8dd159a
 
-FSVERITY_GIT=https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git/
+FSVERITY_GIT=https://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git
 FSVERITY_COMMIT=ddc6bc9daeb79db932aa12edb85c7c2f4647472a
 
 IMA_EVM_UTILS_GIT=https://git.code.sf.net/p/linux-ima/ima-evm-utils.git


### PR DESCRIPTION
See the announcement at "[ANNOUNCE] Moving the fsverity-utils git repo" (https://lore.kernel.org/r/Y9GKm+hcm70myZkr@sol.localdomain).

Signed-off-by: Eric Biggers <ebiggers@google.com>