### PR TITLE
Documentation: alignment fix in quickstart

### DIFF
--- a/Documentation/kvm-quickstart.md
+++ b/Documentation/kvm-quickstart.md
@@ -37,7 +37,7 @@
     the commands:
 
         kvm-xfstests install-kconfig
-	kvm-xfstests kbuild
+        kvm-xfstests kbuild
 
 6.  Run "kvm-xfstests smoke" to do a quick test.  Or "kvm-xfstests
     -g auto" to do a full test.  You can also run specific tests on


### PR DESCRIPTION
Align instructions to build the guest kernel: both will be in the code box.

Fixes: 72cdf994b221 ("Create and reorganzize top-level directories")