### PR TITLE
kvm-xfstests.boot: fix broken VM timeout

### DIFF
--- a/test-appliance/files/etc/systemd/system/kvm-xfstests.service
+++ b/test-appliance/files/etc/systemd/system/kvm-xfstests.service
@@ -8,7 +8,8 @@ Wants=local-fs.target network-online.target network.target
 Type=oneshot
 IgnoreSIGPIPE=no
 ExecStart=/root/kvm-xfstests.boot
-TimeoutSec=0
+TimeoutStartSec=0
+TimeoutStopSec=10
 StandardOutput=tty
 
 [Install]


### PR DESCRIPTION
Perhaps the defaults in debian changed or something but on recent commit tytso/master:a91591289b55c, VM timeout does not seem to be working. At this commit,

- I set the OnBootSec=20m in test-appliance/files/etc/systemd/system/gce-finalize.timer
- Added a 3hr sleep to a test
- Ran plain gce-xfstests (no ltm) including that test

At a glance, looking at the report, it appears like everything worked correctly. At the test with the sleep, it reports "Shutdown reason: Timeout". But looking closely at the timestamps, it didn't actually finish until after 3hrs, implying the test ran to completion. I added some debug prints, and it seems to get stuck at systemctl stop kvm-xfstests in test-appliance/files/usr/local/sbin/gce-shutdown - this makes sense as it is after we record the shutdown reason, hence the reports showing the Timeout msg. I tinkered with the service timeout/kill settings and I think what is happening is that we used TimeoutSec=0 to make sure the kvm-xfstests.boot script (ExecStart) never quits. But, TimeoutSec is a shorthand for configuring both TimeoutStartSec= and TimeoutStopSec= to the specified value. If I understand the docs for TimeoutStopSec correctly, in our situation, TimeoutStopSec is the amount of time to wait between sending the initial SIGTERM and the subsequent SIGKILL. When set to 0, I'm not sure if the SIGKILL, or even SIGTERM, ever gets sent.

However, if we set TimeoutStopSec to a non-zero value, the timeout starts working as expected. It also works with leaving TimeSec=0 and setting KillSignal=SIGKILL. We might as well let it try the SIGTERM first, so lets do the TimeoutStopSec approach.