### PR TITLE
run-tests: fix sourcing of combine-xfs-mkfs-opts

### DIFF
--- a/test-appliance/files/root/fs/xfs/config
+++ b/test-appliance/files/root/fs/xfs/config
@@ -2,7 +2,13 @@
 # Configuration file for xfs
 #
 
-. /usr/local/lib/combine-xfs-mkfs-opts
+if test -f /usr/local/lib/combine-xfs-mkfs-opts; then
+    . /usr/local/lib/combine-xfs-mkfs-opts
+elif test -f $DIR/../test-appliance/files/usr/local/lib/combine-xfs-mkfs-opts; then
+    . $DIR/../test-appliance/files/usr/local/lib/combine-xfs-mkfs-opts
+else
+    echo "Error: Could not find file combine-xfs-mkfs-opts"
+fi
 
 DEFAULT_MKFS_OPTIONS="-bsize=4096"
 


### PR DESCRIPTION
We recently added the following line

. /usr/local/lib/combine-xfs-mkfs-opts

to test-appliance/files/root/fs/xfs/config. But, this file is also run via gce-xfstests ltm -c <cfg>  ->  parse_cli  -> -c parsing -> validate_config_name. Since validate_config_name is not run from the test appliance, we get a "file missing" error when it tries to source the path to combine-xfs-mkfs-opts.

Fixes: f62433b74146 ("test-appliance: combine xfs's lts configuration with its mkfs option")