### PR TITLE
gen-image: only run systemctl disable if unit exists

### DIFF
--- a/test-appliance/gen-image
+++ b/test-appliance/gen-image
@@ -457,10 +457,10 @@ run_in_chroot "systemctl enable telnet-getty@ttyS1.service"
 run_in_chroot "systemctl enable telnet-getty@ttyS2.service"
 run_in_chroot "systemctl enable telnet-getty@ttyS3.service"
 run_in_chroot "systemctl mask serial-getty@hvc0.service"
-run_in_chroot "systemctl disable multipathd"
-run_in_chroot "systemctl disable nvmf-autoconnect"
-run_in_chroot "systemctl disable nfs-server"
-run_in_chroot  "systemctl disable nfs-blkmap"
+run_in_chroot "! systemctl -q list-unit-files multipathd || systemctl disable multipathd"
+run_in_chroot "! systemctl -q list-unit-files nvmf-autoconnect || systemctl disable nvmf-autoconnect"
+run_in_chroot "! systemctl -q list-unit-files nfs-server || systemctl disable nfs-server"
+run_in_chroot "! systemctl -q list-unit-files nfs-blkmap || systemctl disable nfs-blkmap"
 find $ROOTDIR/usr/share/doc -type f -print0 ! -name copyright | xargs -0 rm
 find $ROOTDIR/usr/share/doc -mindepth 2 -type l -print0 | xargs -0 rm
 find $ROOTDIR/usr/share/doc -type d -print0 | xargs -0 rmdir --ignore-fail-on-non-empty -p


### PR DESCRIPTION
Since commit 821ba916a41f0ce3749ae0, we disable the nfs server. This led to build failure with the following error:

Running in chroot: systemctl disable nfs-server
Failed to disable unit, unit nfs-server.service does not exist.

Let's only run disable if the unit exists.

(using `! list-unit-files || disable` lets us return true if we skip disabling because the unit file does not exist)