### PR TITLE
gen-image: allow disable nfs-server to fail

### DIFF
--- a/test-appliance/gen-image
+++ b/test-appliance/gen-image
@@ -459,8 +459,8 @@ run_in_chroot "systemctl enable telnet-getty@ttyS3.service"
 run_in_chroot "systemctl mask serial-getty@hvc0.service"
 run_in_chroot "systemctl disable multipathd"
 run_in_chroot "systemctl disable nvmf-autoconnect"
-run_in_chroot "systemctl disable nfs-server"
-run_in_chroot  "systemctl disable nfs-blkmap"
+run_in_chroot "systemctl disable nfs-server || true"
+run_in_chroot "systemctl disable nfs-blkmap || true"
 find $ROOTDIR/usr/share/doc -type f -print0 ! -name copyright | xargs -0 rm
 find $ROOTDIR/usr/share/doc -mindepth 2 -type l -print0 | xargs -0 rm
 find $ROOTDIR/usr/share/doc -type d -print0 | xargs -0 rmdir --ignore-fail-on-non-empty -p


### PR DESCRIPTION
Since commit 821ba91, we disable the nfs server. This led to build failure with the following error:

Running in chroot: systemctl disable nfs-server
Failed to disable unit, unit nfs-server.service does not exist.

Let the build continue if the systemctl command fails.