### PR TITLE
gce-shutdown: grab RESULT_BASE before copy_xunit

### DIFF
--- a/test-appliance/files/usr/local/sbin/gce-shutdown
+++ b/test-appliance/files/usr/local/sbin/gce-shutdown
@@ -77,10 +77,10 @@ then
 	     >> /results/runtests.log
     fi
 
+    RESULT_BASE="$(cat /run/result-base)"
     copy_xunit_results
     if test "$shutdown_reason" == "Timeout"
     then
-	RESULT_BASE="$(cat /run/result-base)"
 	last_test="$(tail -n 1 "$RESULT_BASE/completed")"
 	# if we have something written to completed (last started test)
 	# and it does not show up in the result.xml, treat this test


### PR DESCRIPTION
copy_xunit_results tries to syncfs on $RESULT_BASE, we should be setting this variable before calling copy_xunit_results.

Fixes: b1bf3ca2f07d ("ltm: add flag to use vm timeout")