### PR TITLE
gce-xfstests: add GCE_REPORT_FAIL_EMAIL

### DIFF
--- a/Documentation/gce-xfstests.md
+++ b/Documentation/gce-xfstests.md
@@ -154,6 +154,10 @@ configuration parameters in order to have reports e-mailed to you:
 * GCE_REPORT_EMAIL
   * The comma separated list of email addresses for which test
     results should be sent.
+* GCE_REPORT_FAIL_EMAIL
+  * If set, reports with hard failures or errors will be redirected
+    to this comma separated recipient list instead of going to
+    GCE_REPORT_EMAIL.
 * GCE_REPORT_SENDER
   * The email used as the sender for the test report.  This defaults
     to the first address in the `GCE_REPORT_EMAIL` configuration

--- a/run-fstests/gce-xfstests
+++ b/run-fstests/gce-xfstests
@@ -826,6 +826,7 @@ SENDGRID_API_KEY="$GCE_SG_API"
 {
     declare -p GCE_REPORT_SENDER
     declare -p GCE_REPORT_EMAIL
+    declare -p GCE_REPORT_FAIL_EMAIL
     declare -p GCE_JUNIT_EMAIL
     declare -p SENDGRID_API_KEY
     declare -p GCE_UPLOAD_SUMMARY
@@ -1261,6 +1262,11 @@ fi
 if test -n "$GCE_REPORT_EMAIL"
 then
     ARG="$ARG report_email=$GCE_REPORT_EMAIL"
+fi
+
+if test -n "$GCE_REPORT_FAIL_EMAIL"
+then
+    ARG="$ARG report_fail_email=$GCE_REPORT_FAIL_EMAIL"
 fi
 
 if test -n "$GCE_JUNIT_EMAIL"

--- a/run-fstests/util/gce-do-setup
+++ b/run-fstests/util/gce-do-setup
@@ -242,15 +242,20 @@ if test -n "$bad_config"; then
     exit 1
 fi
 
-if test -n "$GCE_REPORT_EMAIL" ; then
+addr=
+if test -n "$GCE_REPORT_EMAIL" -o -n "$GCE_REPORT_FAIL_EMAIL"; then
     if test -z "$GCE_SG_API" ; then
 	echo "Missing Sendgrid API key; you need to set GCE_SG_API"
     fi
     if test -n "$GCE_REPORT_SENDER" ; then
 	addr="$GCE_REPORT_SENDER"
-    else
+    elif test -n "$GCE_REPORT_EMAIL" ; then
 	# take first email in the comma separated list
 	addr="${GCE_REPORT_EMAIL%,*}"
+    else
+	# this is needed to support the case where we only
+	# want emails sent upon failure
+	addr="${GCE_REPORT_FAIL_EMAIL%,*}"
     fi
     addr=$(echo $addr | sed -e 's/.*@//')
     spf=$(dig -t txt +short "$addr" | grep v=spf1)
@@ -264,8 +269,8 @@ if test -n "$GCE_REPORT_EMAIL" ; then
 	echo -e "If you can change the SPF record, please add"
 	echo -e "'include:sendgrid.net' before the 'all' mechanism"
 	echo -e "in the spf record for $addr.  Otherwise, mail sent to"
-	echo -e "'$GCE_REPORT_EMAIL' from '$GCE_REPORT_SENDER' may be"
-	echo -e "rejected as spam.\n"
+	echo -e "'$GCE_REPORT_EMAIL $GCE_REPORT_FAIL_EMAIL' from"
+	echo -e "'$GCE_REPORT_SENDER' may be rejected as spam.\n"
     fi
 fi
 

--- a/run-fstests/util/gce-kcs-funcs
+++ b/run-fstests/util/gce-kcs-funcs
@@ -49,6 +49,9 @@ function send_to_kcs() {
     if [ -n "${GCE_REPORT_EMAIL+x}" ]; then
 	KCS_OPTS="${KCS_OPTS:+$KCS_OPTS, }\"report_email\":\"$GCE_REPORT_EMAIL\""
     fi
+    if [ -n "${GCE_REPORT_FAIL_EMAIL+x}" ]; then
+	KCS_OPTS="${KCS_OPTS:+$KCS_OPTS, }\"report_fail_email\":\"$GCE_REPORT_FAIL_EMAIL\""
+    fi
     if [ -n "$COMMIT" ]; then
 	KCS_OPTS="${KCS_OPTS:+$KCS_OPTS, }\"commit_id\":\"$COMMIT\""
     fi

--- a/run-fstests/util/gce-ltm-funcs
+++ b/run-fstests/util/gce-ltm-funcs
@@ -74,6 +74,9 @@ function send_to_ltm() {
     if [ -n "${GCE_REPORT_EMAIL+x}" ]; then
 	LTM_OPTS="${LTM_OPTS:+$LTM_OPTS, }\"report_email\":\"$GCE_REPORT_EMAIL\""
     fi
+    if [ -n "${GCE_REPORT_FAIL_EMAIL+x}" ]; then
+	LTM_OPTS="${LTM_OPTS:+$LTM_OPTS, }\"report_fail_email\":\"$GCE_REPORT_FAIL_EMAIL\""
+    fi
     if [ -n "${GCE_JUNIT_EMAIL+x}" ]; then
 	LTM_OPTS="${LTM_OPTS:+$LTM_OPTS, }\"junit_email\":\"$GCE_JUNIT_EMAIL\""
     fi

--- a/run-fstests/util/parse_cli
+++ b/run-fstests/util/parse_cli
@@ -317,6 +317,7 @@ cpu-type:
 disable-serial
 email:
 enable-serial
+fail-email:
 fail-loop-count:
 gce-disk-spec:
 gce-network:
@@ -798,9 +799,14 @@ while (( $# >= 1 )); do
 	    supported_flavors gce
 	    GCE_REPORT_EMAIL="$1"
 	    ;;
+	--fail-email) shift
+	    supported_flavors gce
+	    GCE_REPORT_FAIL_EMAIL="$1"
+	    ;;
 	--no-email)
 	    supported_flavors gce
 	    GCE_REPORT_EMAIL=""
+	    GCE_REPORT_FAIL_EMAIL=""
 	    ;;
 	--junit-email) shift
 	    supported_flavors gce

--- a/test-appliance/files/root/runtests.sh
+++ b/test-appliance/files/root/runtests.sh
@@ -543,7 +543,9 @@ done
 runtests_after_tests
 
 /usr/local/bin/gen_results_summary $RESULTS \
-	--merge_file /tmp/results.xml > $RESULTS/report
+	--merge_file /tmp/results.xml \
+	--output_file $RESULTS/report \
+	--check_failure
 
 echo "-------------------- Summary report"
 

--- a/test-appliance/files/usr/local/bin/gen_results_summary
+++ b/test-appliance/files/usr/local/bin/gen_results_summary
@@ -10,15 +10,24 @@ def main():
     parser.add_argument('--merge_file',
                         help='Combined output file for XML xUnit')
     parser.add_argument('--output_file', help='Combined text output file')
+    parser.add_argument('--check_failure', help='Create .failed file if unclean test run',
+                        action='store_true')
     parser.add_argument('--verbose', help='Generate a verbose output',
                         action='store_true')
     parser.add_argument('--verbosity_threshold', help='Threshold limit for verbose output',
                         action='store', type=int, default=30)
     args = parser.parse_args()
 
+    check_failure_fn = None
+    if args.check_failure:
+        if args.output_file:
+            check_failure_fn = args.output_file + ".failed"
+        else:
+            check_failure_fn = ".failed"
+
     if gen_results_summary(args.results_dir, args.output_file,
                            args.merge_file, args.verbose,
-                           args.verbosity_threshold) == 0:
+                           args.verbosity_threshold, check_failure_fn) == 0:
         sys.exit('No results file found in ' + args.results_dir)
 
 if __name__ == "__main__":

--- a/test-appliance/files/usr/local/lib/gce-server/kcs/build.go
+++ b/test-appliance/files/usr/local/lib/gce-server/kcs/build.go
@@ -38,7 +38,7 @@ func StartBuild(c server.TaskRequest, testID string, serverLog *logrus.Entry) {
 
 	buildLog := logging.KCSLogDir + testID + ".build"
 	subject := "xfstests KCS build failure " + testID
-	defer email.ReportFailure(log, buildLog, c.Options.ReportEmail, subject)
+	defer email.ReportFailure(log, buildLog, c.Options.ReportFailEmail, subject)
 
 	gsBucket, err := gcp.GceConfig.Get("GS_BUCKET")
 	check.Panic(err, log, "Failed to get gs bucket config")

--- a/test-appliance/files/usr/local/lib/gce-server/kcs/main.go
+++ b/test-appliance/files/usr/local/lib/gce-server/kcs/main.go
@@ -40,6 +40,11 @@ func runCompile(w http.ResponseWriter, r *http.Request, serverLog *logrus.Entry)
 	}).Info("Received build request")
 
 	testID := mymath.GetTimeStamp()
+
+	if c.Options.ReportFailEmail == "" {
+		c.Options.ReportFailEmail = c.Options.ReportEmail
+	}
+
 	response := server.SimpleResponse{
 		Status: true,
 		TestID: testID,

--- a/test-appliance/files/usr/local/lib/gce-server/ltm/build.go
+++ b/test-appliance/files/usr/local/lib/gce-server/ltm/build.go
@@ -20,7 +20,7 @@ func ForwardKCS(req server.TaskRequest, testID string) {
 	defer logging.CloseLog(log)
 
 	subject := "xfstests LTM forwarding request failure " + testID
-	defer email.ReportFailure(log, logFile, req.Options.ReportEmail, subject)
+	defer email.ReportFailure(log, logFile, req.Options.ReportFailEmail, subject)
 
 	server.SendInternalRequest(req, log, true)
 }

--- a/test-appliance/files/usr/local/lib/gce-server/ltm/main.go
+++ b/test-appliance/files/usr/local/lib/gce-server/ltm/main.go
@@ -47,6 +47,10 @@ func runTests(w http.ResponseWriter, r *http.Request, log *logrus.Entry) {
 
 	testID := mymath.GetTimeStamp()
 
+	if c.Options.ReportFailEmail == "" {
+		c.Options.ReportFailEmail = c.Options.ReportEmail
+	}
+
 	if c.ExtraOptions == nil {
 		if c.Options.TestRunID == "" {
 			log.WithField("testID", testID).Info("User request, generating testID")

--- a/test-appliance/files/usr/local/lib/gce-server/ltm/watcher.go
+++ b/test-appliance/files/usr/local/lib/gce-server/ltm/watcher.go
@@ -35,14 +35,15 @@ type GitWatcher struct {
 	testID  string
 	origCmd string
 
-	gsBucket       string
-	bucketSubdir   string
-	reportReceiver string
-	testRequest    server.TaskRequest
-	testHistory    []server.TestInfo
-	packHistory    []string
-	historyLock    sync.Mutex
-	buildID        int
+	gsBucket           string
+	bucketSubdir       string
+	reportReceiver     string
+	reportFailReceiver string
+	testRequest        server.TaskRequest
+	testHistory        []server.TestInfo
+	packHistory        []string
+	historyLock        sync.Mutex
+	buildID            int
 
 	repo *git.RemoteRepository
 	done chan bool
@@ -110,13 +111,14 @@ func NewGitWatcher(c server.TaskRequest, testID string) *GitWatcher {
 		testID:  testID,
 		origCmd: origCmd,
 
-		gsBucket:       gsBucket,
-		bucketSubdir:   bucketSubdir,
-		reportReceiver: c.Options.ReportEmail,
-		testRequest:    c,
-		testHistory:    []server.TestInfo{},
-		packHistory:    []string{},
-		buildID:        0,
+		gsBucket:           gsBucket,
+		bucketSubdir:       bucketSubdir,
+		reportReceiver:     c.Options.ReportEmail,
+		reportFailReceiver: c.Options.ReportFailEmail,
+		testRequest:        c,
+		testHistory:        []server.TestInfo{},
+		packHistory:        []string{},
+		buildID:            0,
 
 		repo:       repo,
 		done:       done,
@@ -148,7 +150,7 @@ func (watcher *GitWatcher) watch() {
 	var skip, skipAmount int
 
 	subject := fmt.Sprintf("xfstests LTM watcher failure " + watcher.testID)
-	defer email.ReportFailure(watcher.log, watcher.logFile, watcher.reportReceiver, subject)
+	defer email.ReportFailure(watcher.log, watcher.logFile, watcher.reportFailReceiver, subject)
 
 	checkTicker := time.NewTicker(checkInterval)
 	defer checkTicker.Stop()

--- a/test-appliance/files/usr/local/lib/gce-server/util/parser/parser.go
+++ b/test-appliance/files/usr/local/lib/gce-server/util/parser/parser.go
@@ -27,6 +27,7 @@ var invalidOpts = []string{
 	"--bucket-subdir",
 	"--gs-bucket",
 	"--email",
+	"--fail-email",
 	"--junit-email",
 	"--gce-zone",
 	"--testrunid",

--- a/test-appliance/files/usr/local/lib/gce-server/util/server/server.go
+++ b/test-appliance/files/usr/local/lib/gce-server/util/server/server.go
@@ -118,23 +118,24 @@ const (
 
 // UserOptions contains configs user sends to LTM or KCS.
 type UserOptions struct {
-	NoRegionShard  bool   `json:"no_region_shard"`
-	BucketSubdir   string `json:"bucket_subdir"`
-	GsKernel       string `json:"gs_kernel"`
-	ReportEmail    string `json:"report_email"`
-	JunitEmail     string `json:"junit_email"`
-	CommitID       string `json:"commit_id"`
-	GitRepo        string `json:"git_repo"`
-	BranchName     string `json:"branch_name"`
-	UnWatch        string `json:"unwatch"`
-	BadCommit      string `json:"bad_commit"`
-	GoodCommit     string `json:"good_commit"`
-	KConfig        string `json:"kconfig"`
-	KConfigOpts    string `json:"kconfig_opts"`
-	KbuildOpts     string `json:"kbuild_opts"`
-	Arch           string `json:"arch"`
-	MonitorTimeout string `json:"monitor_timeout"`
-	TestRunID      string `json:"test_run_id"`
+	NoRegionShard   bool   `json:"no_region_shard"`
+	BucketSubdir    string `json:"bucket_subdir"`
+	GsKernel        string `json:"gs_kernel"`
+	ReportEmail     string `json:"report_email"`
+	ReportFailEmail string `json:"report_fail_email"`
+	JunitEmail      string `json:"junit_email"`
+	CommitID        string `json:"commit_id"`
+	GitRepo         string `json:"git_repo"`
+	BranchName      string `json:"branch_name"`
+	UnWatch         string `json:"unwatch"`
+	BadCommit       string `json:"bad_commit"`
+	GoodCommit      string `json:"good_commit"`
+	KConfig         string `json:"kconfig"`
+	KConfigOpts     string `json:"kconfig_opts"`
+	KbuildOpts      string `json:"kbuild_opts"`
+	Arch            string `json:"arch"`
+	MonitorTimeout  string `json:"monitor_timeout"`
+	TestRunID       string `json:"test_run_id"`
 }
 
 // InternalOptions contains configs used by LTM and KCS internally.

--- a/test-appliance/files/usr/local/sbin/gce-shutdown
+++ b/test-appliance/files/usr/local/sbin/gce-shutdown
@@ -93,7 +93,8 @@ then
 	if test -s /tmp/results.xml && test ! -s /results/report
 	then
 	    /usr/local/bin/gen_results_summary /results \
-	        --merge_file /tmp/results.xml > /results/report
+	        --merge_file /tmp/results.xml --check_failure \
+	        --output_file /results/report
 	fi
     fi
 
@@ -112,28 +113,46 @@ then
     fi
 
     REPORT_EMAIL=$(gce_attribute report_email)
+    REPORT_FAIL_EMAIL=$(gce_attribute report_fail_email)
+    # default to use normal email if no fail email specified
+    if test -z "$REPORT_FAIL_EMAIL"
+    then
+	REPORT_FAIL_EMAIL="$REPORT_EMAIL"
+    fi
     JUNIT_EMAIL=$(gce_attribute junit_email)
     run_hooks send-email
-    if test -n "$REPORT_EMAIL" -a -n "$SENDGRID_API_KEY"
+
+    if [  -n "$REPORT_EMAIL" -o  -n "$REPORT_FAIL_EMAIL" ] && [ -n "$SENDGRID_API_KEY" ]
     then
 	if test -s /results/report
 	then
 	    RESULTS_REPORT=/results/report
+	    if test -e "${RESULTS_REPORT}.failed"
+	    then
+		REPORT_EMAIL="$REPORT_FAIL_EMAIL"
+	    fi
 	else
 	    RESULTS_REPORT=/results/runtests.log
+	    REPORT_EMAIL="$REPORT_FAIL_EMAIL"
 	fi
 	subj="$suite results $TESTRUNID - $(uname -r)"
 	if test -f /run/powerbtn
 	then
 	    subj="$subj - test run aborted"
+	    REPORT_EMAIL="$REPORT_FAIL_EMAIL"
 	fi
 	if test -z "$GCE_REPORT_SENDER"
 	then
 	    GCE_REPORT_SENDER="$USER@$HOSTNAME"
 	fi
 	export SENDGRID_API_KEY
-	/usr/local/sbin/send-mail.py --sender "$GCE_REPORT_SENDER" \
-		-s "$subj" "$REPORT_EMAIL" < "$RESULTS_REPORT"
+	# REPORT_EMAIL could be empty at this point if GCE_REPORT_EMAIL is
+	# not set, GCE_REPORT_FAIL_EMAIL is set, and we had no failures
+	if test -n "$REPORT_EMAIL"
+	then
+	    /usr/local/sbin/send-mail.py --sender "$GCE_REPORT_SENDER" \
+	        -s "$subj" "$REPORT_EMAIL" < "$RESULTS_REPORT"
+	fi
     fi
     if test -n "$JUNIT_EMAIL" -a -n "$SENDGRID_API_KEY" -a -f /tmp/results.xml
     then


### PR DESCRIPTION
When this config option is set, test runs with *hard* failures or test infra errors send their reports to GCE_REPORT_FAIL_EMAIL instead of to GCE_REPORT_EMAIL. If this option is not set, all emails go to GCE_REPORT_EMAIL.

When we generate the summary report, if --check_failures is set, we create a report.failed file if problems were found. When we go to send emails, we check for this file and then route the email correspondingly. We also send emails to GCE_REPORT_FAIL_EMAIL if the ltm server detects issues. Support is included for normal gce-xfstests runs, ltm runs, and kcs builds.

Tested passing and failing tests:
  with --fail-email flag and with config param GCE_REPORT_FAIL_EMAIL
  with and without LTM
  with REPORT_EMAIL="" and REPORT_FAIL_EMAIL=<email>
  with mutliple emails in REPORT_FAIL_EMAIL

Ensured the following get routed as failure:
  broken kcs build via ltm --commit <bad sha>
  errors resulting in ltm machine reboots
  timeouts via LTM monitor timeout
  timeouts via watchdog timeout with and without LTM