### PR TITLE
test-appliance: update xfs/v4 config

### DIFF
--- a/test-appliance/files/root/fs/xfs/cfg/v4
+++ b/test-appliance/files/root/fs/xfs/cfg/v4
@@ -1,3 +1,3 @@
 SIZE=small
-export XFS_MKFS_OPTIONS="-m crc=0"
+export XFS_MKFS_OPTIONS="-m crc=0,finobt=0,rmapbt=0,reflink=0,autofsck=none,inobtcount=0,bigtime=0 -i sparse=0 -d cowextsize=0"
 TESTNAME="XFS v4 (crc=0)"


### PR DESCRIPTION
xfs/v4 doesn't run on the new appliance with mkfs.xfs complaining

"finobt not supported without CRC support"

A comment from mkfs.xfs code says the following:

 * The kernel doesn't support crc=0,finobt=1 filesystems.
 * If crcs are not enabled and the user has not explicitly
 * turned finobt on, then silently turn it off to avoid an
 * unnecessary warning.
 * If the user explicitly tried to use crc=0,finobt=1,
 * then issue an error.
 * The same is also true for sparse inodes and reflink.

In the v4 config file, all we do is set crc=0. We never intended to run with crc=0,finobt=1, so let's update the config to explicitly set finobt=0. After fixing this,, there were similar complaints about other features that require crc enabled. Explicitly disable those as well.

If I had to guess, I suspect this might have to do with us attempting to allow command line overwriting of mkfs options via combine-xfs-mkfs-opts but the fix was simple enough that I didn't investigate further.